### PR TITLE
Multiple updates to WindowResizer including custom size

### DIFF
--- a/assets/js/resizer.js
+++ b/assets/js/resizer.js
@@ -37,6 +37,9 @@
 
 	var sizesDiv = document.getElementById('sizes');
 	var outerHeight, innerHeight, heightDelta;
+	var customBtn = document.querySelector("#set-custom");
+	var customWidth = document.querySelector("#custom-width");
+	var customHeight = document.querySelector("#custom-height");
 
 	chrome.windows.get(chrome.windows.WINDOW_ID_CURRENT, function(w){
 		outerHeight = w.height;
@@ -54,13 +57,18 @@
 
 
 	function populatePopup() {
-		// calculate the difference between inner and outer height to get chrome height
 		heightDelta = outerHeight - innerHeight;
+		// setup custom size button
+		customBtn.onclick = function() {
+			chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, {width:Number(customWidth.value), height:Number(customHeight.value)});
+		}
 
 		for(var k in sizes) {
-			// update height to fix vertical loss due to window chrome
+
 			sizes[k].height += heightDelta;
+
 			if(!sizes.hasOwnProperty(k)) continue;
+
 			var newElement = document.createElement('button');
 			newElement.className = 'btn btn-primary btn-small btn-block size';
 			newElement.innerText = k;

--- a/assets/js/resizer.js
+++ b/assets/js/resizer.js
@@ -36,16 +36,40 @@
 
 
 	var sizesDiv = document.getElementById('sizes');
-	for(var k in sizes) {
-		if(!sizes.hasOwnProperty(k)) continue;
+	var outerHeight, innerHeight, heightDelta;
 
-		var newElement = document.createElement('button');
-		newElement.className = 'btn btn-primary btn-small btn-block size';
-		newElement.innerText = k;
-		newElement.onclick = function () {
-			chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, sizes[this.innerText]);
-		};
+	chrome.windows.get(chrome.windows.WINDOW_ID_CURRENT, function(w){
+		outerHeight = w.height;
+		if(innerHeight) {
+			populatePopup();
+		}
+	});
 
-		sizesDiv.appendChild(newElement);
+	chrome.tabs.query({active: true},function(t){
+		innerHeight = t[0].height;
+		if(outerHeight) {
+			populatePopup();
+		}
+	});
+
+
+	function populatePopup() {
+		// calculate the difference between inner and outer height to get chrome height
+		heightDelta = outerHeight - innerHeight;
+
+		for(var k in sizes) {
+			// update height to fix vertical loss due to window chrome
+			sizes[k].height += heightDelta;
+			if(!sizes.hasOwnProperty(k)) continue;
+			var newElement = document.createElement('button');
+			newElement.className = 'btn btn-primary btn-small btn-block size';
+			newElement.innerText = k;
+			newElement.onclick = function () {
+				chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, sizes[this.innerText]);
+			};
+
+			sizesDiv.appendChild(newElement);
+		}
+
 	}
 })();

--- a/assets/js/resizer.js
+++ b/assets/js/resizer.js
@@ -29,6 +29,10 @@
 			width: 1920,
 			height: 1080
 		},
+		'1920x720': {
+			width: 1920,
+			height: 720
+		},
 		'Fullscreen': {
 			state: 'maximized'
 		}
@@ -40,6 +44,7 @@
 	var customBtn = document.querySelector("#set-custom");
 	var customWidth = document.querySelector("#custom-width");
 	var customHeight = document.querySelector("#custom-height");
+	var sizeInner = document.querySelector('#size-inner');
 
 	chrome.windows.get(chrome.windows.WINDOW_ID_CURRENT, function(w){
 		outerHeight = w.height;
@@ -57,15 +62,21 @@
 
 
 	function populatePopup() {
+		// calculate height lost to window chrome
 		heightDelta = outerHeight - innerHeight;
+
 		// setup custom size button
 		customBtn.onclick = function() {
-			chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, {width:Number(customWidth.value), height:Number(customHeight.value)});
+			var w = Number(customWidth.value);
+			var h = Number(customHeight.value);
+			if(sizeInner.checked) {
+				h += heightDelta;
+			}
+
+			chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, {width: w, height: h});
 		}
 
 		for(var k in sizes) {
-
-			sizes[k].height += heightDelta;
 
 			if(!sizes.hasOwnProperty(k)) continue;
 
@@ -73,11 +84,21 @@
 			newElement.className = 'btn btn-primary btn-small btn-block size';
 			newElement.innerText = k;
 			newElement.onclick = function () {
-				chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, sizes[this.innerText]);
+				var settingsObj = {};
+				if(sizes[this.innerText].height) {
+					settingsObj.width = sizes[this.innerText].width;
+					settingsObj.height = sizes[this.innerText].height;
+					if(sizeInner.checked) {
+						settingsObj.height += heightDelta;
+					}
+				}
+				else {
+					settingsObj = sizes[this.innerText];
+				}
+				chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, settingsObj);
 			};
 
 			sizesDiv.appendChild(newElement);
 		}
-
 	}
 })();

--- a/assets/js/resizer.js
+++ b/assets/js/resizer.js
@@ -29,10 +29,6 @@
 			width: 1920,
 			height: 1080
 		},
-		'1920x720': {
-			width: 1920,
-			height: 720
-		},
 		'Fullscreen': {
 			state: 'maximized'
 		}

--- a/popup.html
+++ b/popup.html
@@ -1,28 +1,60 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Chrome Window Resizer</title>
-        <link rel="stylesheet" href="/assets/css/bootstrap.min.css"/>
-        <style>
-            body {
-                width: 250px;
-            }
-            .panel {
-                margin-bottom: 0;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="panel panel-primary">
-            <div class="panel-heading">
-                <h3 class="panel-title">Window Resizer</h3>
-            </div>
-            <div class="panel-body">
-                <div id="sizes"></div>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Chrome Window Resizer</title>
+    <link rel="stylesheet" href="/assets/css/bootstrap.min.css" />
+    <style>
+    body {
+        width: 250px;
+    }
+    .panel {
+        margin-bottom: 0;
+    }
+    #custom {
+        margin: 0 0 5px 0;
+    }
+    #custom input {
+        width: 70px;
+        float: left;
+        border-radius: 3px;
+        height: 30px;
+    }
+    #custom button {
+        width: 49px;
+        float: right;
+        display: block;
+        margin: 0 0 5px 0;
+    }
+    #custom span {
+        display: block;
+        float: left;
+        width: 20px;
+        line-height: 30px;
+        text-align: center;
+    }
+    </style>
+</head>
+
+<body>
+    <div class="panel panel-primary">
+        <div class="panel-heading">
+            <h3 class="panel-title">Window Resizer</h3>
+        </div>
+        <div class="panel-body">
+            <div id="sizes">
+                <div id="custom">
+                    <input type="number" id="custom-width" value="1280" step="1">
+                    <span>X</span>
+                    <input type="number" id="custom-height" value="720" step="1">
+                    <button id="set-custom" class="btn btn-primary btn-small btn-block size">Set</button>
+                </div>
             </div>
         </div>
+    </div>
 
-        <script src="/assets/js/resizer.js"></script>
-    </body>
+    <script src="/assets/js/resizer.js"></script>
+</body>
+
 </html>

--- a/popup.html
+++ b/popup.html
@@ -13,26 +13,33 @@
         margin-bottom: 0;
     }
     #custom {
-        margin: 0 0 5px 0;
+        margin: 5px 0;
     }
     #custom input {
         width: 70px;
         float: left;
         border-radius: 3px;
-        height: 30px;
+        height: 35px;
+        padding: 0 5px;
     }
     #custom button {
         width: 49px;
         float: right;
         display: block;
-        margin: 0 0 5px 0;
     }
     #custom span {
         display: block;
         float: left;
         width: 20px;
-        line-height: 30px;
+        line-height: 37px;
         text-align: center;
+    }
+    .settings {
+        clear: both;
+        padding-top: 10px;
+    }
+    .settings p {
+        margin: 5px;
     }
     </style>
 </head>
@@ -43,14 +50,18 @@
             <h3 class="panel-title">Window Resizer</h3>
         </div>
         <div class="panel-body">
-            <div id="sizes">
-                <div id="custom">
-                    <input type="number" id="custom-width" value="1280" step="1">
-                    <span>X</span>
-                    <input type="number" id="custom-height" value="720" step="1">
-                    <button id="set-custom" class="btn btn-primary btn-small btn-block size">Set</button>
-                </div>
+            <div id="sizes"></div>
+            <div id="custom">
+                <input type="number" id="custom-width" value="1280" step="1">
+                <span>X</span>
+                <input type="number" id="custom-height" value="720" step="1">
+                <button id="set-custom" class="btn btn-primary btn-small btn-block size">Set</button>
             </div>
+            <div class="settings">
+                <label><input type="radio" name="size-type" id="size-inner" checked> Resize inner viewable area</label>
+                <label><input type="radio" name="size-type" id="size-outer"> <span class="glyphicon glyphicon-cog"></span>Resize outer window</label>
+            </div>
+
         </div>
     </div>
 


### PR DESCRIPTION
First off, thanks for making a very useful and clean Chrome extension. 

My fork came about because the `chrome.windows.update` method on Chrome for Mac sets the outer bounds of the window size, but I needed to set the inner viewable area, not the outer window. I set about making some edits and ended up adding several features:
- Now sets the inner window size (default). 
- You can change which style of resize is used via radio buttons.
- Custom size inputs implemented.

Known Issues: 
- The settings are not saved, and the UI returns to defaults every time it opens. I thought about using `localStorage` as a way to save and restore settings, but got lazy.
- My added code is functional, but inelegant. Apologies for making a mess.
- I'm on a Mac, so this is untested on Chrome for Windows. Actually, it's pretty much untested outside of two Macs running current Chrome builds.

Thanks again.
